### PR TITLE
Avro bugfixes

### DIFF
--- a/avro/src/main/scala/AvroRandomExtractor.scala
+++ b/avro/src/main/scala/AvroRandomExtractor.scala
@@ -1,10 +1,7 @@
 package com.memsql.spark.examples.avro
 
-import collection.JavaConversions._
 import com.memsql.spark.etl.api._
 import com.memsql.spark.etl.utils.PhaseLogger
-import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.sql.{SQLContext, DataFrame, Row}
 import org.apache.spark.sql.types._
@@ -15,6 +12,7 @@ import org.apache.avro.specific.SpecificDatumWriter
 
 import java.io.ByteArrayOutputStream
 
+// Generates an RDD of byte arrays, where each is a serialized Avro record.
 class AvroRandomExtractor extends Extractor {
   var count: Int = 1
   var generator: AvroRandomGenerator = null

--- a/avro/src/main/scala/AvroRandomGenerator.scala
+++ b/avro/src/main/scala/AvroRandomGenerator.scala
@@ -7,30 +7,48 @@ import scala.collection.JavaConversions._
 import scala.util.Random
 
 class AvroRandomGenerator(inSchema: Schema) {
+  // Avoid nested Records, since our destination is a DataFrame.
   val MAX_RECURSION_LEVEL: Int = 1
+
   val topSchema: Schema = inSchema
   val random = new Random
 
   def next(schema: Schema = this.topSchema, level: Int = 0): Any = {
-    if (level > MAX_RECURSION_LEVEL) {
-      return null
-    }
+    if (level <= MAX_RECURSION_LEVEL) {
 
-    schema.getType match {
-      case Schema.Type.BOOLEAN => random.nextBoolean
-      case Schema.Type.DOUBLE => random.nextDouble
-      case Schema.Type.FLOAT => random.nextFloat
-      case Schema.Type.INT => random.nextInt
-      case Schema.Type.LONG => random.nextLong
-      case Schema.Type.NULL => null
-      case Schema.Type.RECORD => {
-        val datum = new GenericData.Record(schema)
-        schema.getFields.map{x => datum.put(x.pos, next(x.schema, level+1))}
-        datum
+      schema.getType match {
+        case Schema.Type.RECORD => {
+          val datum = new GenericData.Record(schema)
+          schema.getFields.foreach {
+            x => datum.put(x.pos, next(x.schema, level + 1))
+          }
+          datum
+        }
+
+        case Schema.Type.UNION => {
+          val types = schema.getTypes
+          // Generate a value using the first type in the union.
+          // "Random type" is also a valid option.
+          next(types(0), level)
+        }
+
+        case _ => generateValue(schema.getType)
       }
-      case Schema.Type.STRING => getRandomString
-      case _ => null
+
+    } else {
+      null
     }
+  }
+
+  def generateValue(avroType: Schema.Type): Any = avroType match {
+    case Schema.Type.BOOLEAN => random.nextBoolean
+    case Schema.Type.DOUBLE => random.nextDouble
+    case Schema.Type.FLOAT => random.nextFloat
+    case Schema.Type.INT => random.nextInt
+    case Schema.Type.LONG => random.nextLong
+    case Schema.Type.NULL => null
+    case Schema.Type.STRING => getRandomString
+    case _ => null
   }
 
   def getRandomString(): String = {

--- a/avro/src/main/scala/AvroToRow.scala
+++ b/avro/src/main/scala/AvroToRow.scala
@@ -5,12 +5,27 @@ import org.apache.spark.sql.Row
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
 
+// Converts an Avro record to a Spark DataFrame row.
+//
+// This assumes that the Avro schema is "flat", i.e. a Record that includes primitive types
+// or unions of primitive types. Unions, and Avro types that don't directly map to Scala types,
+// are converted to Strings and put in a Spark SQL StringType column.
 private class AvroToRow {
-
   def getRow(record: GenericData.Record): Row = {
     Row.fromSeq(record.getSchema.getFields().map(f => {
-      record.get(f.pos)
+      val schema = f.schema()
+      val obj = record.get(f.pos)
+
+      schema.getType match {
+        case Schema.Type.BOOLEAN => obj.asInstanceOf[Boolean]
+        case Schema.Type.DOUBLE => obj.asInstanceOf[Double]
+        case Schema.Type.FLOAT => obj.asInstanceOf[Float]
+        case Schema.Type.INT => obj.asInstanceOf[Int]
+        case Schema.Type.LONG => obj.asInstanceOf[Long]
+        case Schema.Type.NULL => null
+
+        case _ => obj.toString
+      }
     }))
   }
-
 }

--- a/avro/src/main/scala/AvroToSchema.scala
+++ b/avro/src/main/scala/AvroToSchema.scala
@@ -1,11 +1,14 @@
 package com.memsql.spark.examples.avro
 
 import collection.JavaConversions._
-import com.memsql.spark.connector.dataframe.JsonType
 import org.apache.spark.sql.types._
 import org.apache.avro.Schema
-import org.apache.avro.generic.GenericData
 
+// Converts an Avro schema to a Spark DataFrame schema.
+//
+// This assumes that the Avro schema is "flat", i.e. a Record that includes primitive types
+// or unions of primitive types. Unions, and Avro types that don't directly map to Scala types,
+// are converted to Strings and put in a Spark SQL StringType column.
 private object AvroToSchema {
   def getSchema(schema: Schema): StructType = {
     StructType(schema.getFields.map(field => {
@@ -14,11 +17,10 @@ private object AvroToSchema {
       val fieldType = fieldSchema.getType match {
         case Schema.Type.BOOLEAN => BooleanType
         case Schema.Type.DOUBLE => DoubleType
-        case Schema.Type.ENUM => StringType
         case Schema.Type.FLOAT => FloatType
         case Schema.Type.INT => IntegerType
         case Schema.Type.LONG => LongType
-        case Schema.Type.NULL => StringType
+        case Schema.Type.NULL => NullType
         case Schema.Type.STRING => StringType
         case _ => StringType
       }

--- a/avro/src/main/scala/AvroTransformer.scala
+++ b/avro/src/main/scala/AvroTransformer.scala
@@ -6,20 +6,25 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SQLContext, DataFrame, Row}
 import org.apache.spark.sql.types.StructType
 
-import spray.json.JsValue
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.specific.SpecificDatumReader
 
+// Takes DataFrames of byte arrays, where each row is a serialized Avro record.
+// Returns DataFrames of deserialized data, where each field has its own column.
 class AvroTransformer extends Transformer {
-  val parser: Schema.Parser = new Schema.Parser()
-  var reader: SpecificDatumReader[GenericData.Record] = null
-  var avroSchema: Schema = null
-  var schema: StructType = null  
+  var avroSchemaStr: String = null
+  var sparkSqlSchema: StructType = null
 
   def AvroRDDToDataFrame(sqlContext: SQLContext, rdd: RDD[Row]): DataFrame = {
-    val rowRDD: RDD[Row] = rdd.mapPartitions({ partition =>
+
+    val rowRDD: RDD[Row] = rdd.mapPartitions({ partition => {
+      // Create per-partition copies of non-serializable objects
+      val parser: Schema.Parser = new Schema.Parser()
+      val avroSchema = parser.parse(avroSchemaStr)
+      val reader = new SpecificDatumReader[GenericData.Record](avroSchema)
+
       partition.map({ rowOfBytes =>
         val bytes = rowOfBytes(0).asInstanceOf[Array[Byte]]
         val decoder = DecoderFactory.get().binaryDecoder(bytes, null)
@@ -28,21 +33,22 @@ class AvroTransformer extends Transformer {
 
         avroToRow.getRow(record)
       })
-    })
-    sqlContext.createDataFrame(rowRDD, schema)
+    }})
+    sqlContext.createDataFrame(rowRDD, sparkSqlSchema)
   }
 
   override def initialize(sqlContext: SQLContext, config: PhaseConfig, logger: PhaseLogger): Unit = {
     val userConfig = config.asInstanceOf[UserTransformConfig]
+
     val avroSchemaJson = userConfig.getConfigJsValue("avroSchema") match {
       case Some(s) => s
       case None => throw new IllegalArgumentException("avroSchema must be set in the config")
     }
+    avroSchemaStr = avroSchemaJson.toString
 
-    avroSchema = parser.parse(avroSchemaJson.toString)
-    schema = AvroToSchema.getSchema(avroSchema)
-
-    reader = new SpecificDatumReader[GenericData.Record](avroSchema)
+    val parser = new Schema.Parser()
+    val avroSchema = parser.parse(avroSchemaJson.toString)
+    sparkSqlSchema = AvroToSchema.getSchema(avroSchema)
   }
 
   override def transform(sqlContext: SQLContext, df: DataFrame, config: PhaseConfig, logger: PhaseLogger): DataFrame = {

--- a/avro/src/test/scala/test/AvroExtractorSpec.scala
+++ b/avro/src/test/scala/test/AvroExtractorSpec.scala
@@ -3,8 +3,7 @@ package com.memsql.spark.examples.avro
 import com.memsql.spark.etl.api.UserExtractConfig
 import org.apache.spark.streaming._
 import org.apache.spark.sql.SQLContext
-import org.apache.avro.generic.GenericData
-import test.util.{UnitSpec, TestLogger, LocalSparkContext}
+import test.util.{Fixtures, UnitSpec, TestLogger, LocalSparkContext}
 import spray.json._
 
 class ExtractorsSpec extends UnitSpec with LocalSparkContext {
@@ -17,55 +16,15 @@ class ExtractorsSpec extends UnitSpec with LocalSparkContext {
     sqlContext = new SQLContext(sc)
   }
 
-  val avroJsonSchemaTest = """
-    {
-      "count": 5,
-      "avroSchema": {
-        "namespace": "com.memsql.spark.examples.avro",
-        "type": "record",
-        "name": "TestSchema",
-        "fields": [
-          {
-            "name": "testBool",
-            "type": "boolean"
-          },
-          {
-            "name": "testDouble",
-            "type": "double"
-          },
-          {
-            "name": "testFloat",
-            "type": "float"
-          },
-          {
-            "name": "testInt",
-            "type": "int"
-          },
-          {
-            "name": "testLong",
-            "type": "long"
-          },
-          {
-            "name": "testNull",
-            "type": "null"
-          },
-          {
-            "name": "testString",
-            "type": "string"
-          }
-        ]
-      }
-    }
-  """.parseJson
-
-  val avroConfig = UserExtractConfig(class_name = "Test", value = avroJsonSchemaTest)
+  val avroConfig = Fixtures.avroConfig.parseJson
+  val extractConfig = UserExtractConfig(class_name = "Test", value = avroConfig)
   val logger = new TestLogger("test")
 
   "AvroRandomExtractor" should "emit a random DF" in {
     val extract = new AvroRandomExtractor
-    extract.initialize(ssc, sqlContext, avroConfig, 1, logger)
+    extract.initialize(ssc, sqlContext, extractConfig, 1, logger)
 
-    val maybeDf = extract.next(ssc, 1, sqlContext, avroConfig, 1, logger)
+    val maybeDf = extract.next(ssc, 1, sqlContext, extractConfig, 1, logger)
     assert(maybeDf.isDefined)
     assert(maybeDf.get.count == 5)
   }

--- a/avro/src/test/scala/test/AvroRandomGeneratorSpec.scala
+++ b/avro/src/test/scala/test/AvroRandomGeneratorSpec.scala
@@ -3,48 +3,11 @@ package com.memsql.spark.examples.avro
 import org.scalatest._
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
+import test.util.Fixtures
 
 class AvroRandomGeneratorSpec extends FlatSpec {
   "AvroRandomGenerator" should "create Avro objects with random values" in {
-    val avroJsonSchemaStringTest = s"""
-      {
-        "namespace": "com.memsql.spark.examples.avro",
-        "type": "record",
-        "name": "TestSchema",
-        "fields": [
-          {
-            "name": "testBool",
-            "type": "boolean"
-          },
-          {
-            "name": "testDouble",
-            "type": "double"
-          },
-          {
-            "name": "testFloat",
-            "type": "float"
-          },
-          {
-            "name": "testInt",
-            "type": "int"
-          },
-          {
-            "name": "testLong",
-            "type": "long"
-          },
-          {
-            "name": "testNull",
-            "type": "null"
-          },
-          {
-            "name": "testString",
-            "type": "string"
-          }
-        ]
-      }
-    """
-
-    val schema = new Schema.Parser().parse(avroJsonSchemaStringTest)
+    val schema = new Schema.Parser().parse(Fixtures.avroSchema)
     val avroRecord:GenericData.Record = new AvroRandomGenerator(schema).next().asInstanceOf[GenericData.Record]
 
     assert(avroRecord.get("testBool").isInstanceOf[Boolean])
@@ -54,5 +17,6 @@ class AvroRandomGeneratorSpec extends FlatSpec {
     assert(avroRecord.get("testLong").isInstanceOf[Long])
     assert(avroRecord.get("testNull") == null)
     assert(avroRecord.get("testString").isInstanceOf[String])
+    assert(avroRecord.get("testUnion").isInstanceOf[Int])
   }
 }

--- a/avro/src/test/scala/test/AvroToRowSpec.scala
+++ b/avro/src/test/scala/test/AvroToRowSpec.scala
@@ -5,6 +5,7 @@ import com.memsql.spark.connector.dataframe.JsonValue
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
 import org.apache.spark.sql.Row
+import test.util.Fixtures
 
 import collection.JavaConversions._
 import java.nio.ByteBuffer
@@ -12,45 +13,8 @@ import org.scalatest._
 
 class AvroToRowSpec extends FlatSpec {
   "AvroToRow" should "create Spark SQL Rows from Avro objects" in {
-    val avroTestJsonSchemaString:String = s"""
-      {
-        "namespace": "com.memsql.spark.examples.avro",
-        "type": "record",
-        "name": "TestSchema",
-        "fields": [
-          {
-            "name": "testBool",
-            "type": "boolean"
-          },
-          {
-            "name": "testDouble",
-            "type": "double"
-          },
-          {
-            "name": "testFloat",
-            "type": "float"
-          },
-          {
-            "name": "testInt",
-            "type": "int"
-          },
-          {
-            "name": "testLong",
-            "type": "long"
-          },
-          {
-            "name": "testNull",
-            "type": "null"
-          },
-          {
-            "name": "testString",
-            "type": "string"
-          }
-        ]
-      }
-    """
     val parser: Schema.Parser = new Schema.Parser()
-    val avroTestSchema: Schema = parser.parse(avroTestJsonSchemaString)
+    val avroTestSchema: Schema = parser.parse(Fixtures.avroSchema)
 
     val record: GenericData.Record = new GenericData.Record(avroTestSchema)
 
@@ -61,6 +25,7 @@ class AvroToRowSpec extends FlatSpec {
     record.put("testLong", 2147483648L)
     record.put("testNull", null)
     record.put("testString", "Conor")
+    record.put("testUnion", 17)
 
     val row: Row = new AvroToRow().getRow(record)
 
@@ -71,6 +36,7 @@ class AvroToRowSpec extends FlatSpec {
     assert(row.getAs[Long](4) == 2147483648L)
     assert(row.getAs[Null](5) == null)
     assert(row.getAs[String](6) == "Conor")
+    assert(row.getAs[String](7) == "17")
   }
 }
 

--- a/avro/src/test/scala/test/AvroToSchemaSpec.scala
+++ b/avro/src/test/scala/test/AvroToSchemaSpec.scala
@@ -4,49 +4,12 @@ import com.memsql.spark.connector.dataframe.JsonType
 import org.apache.spark.sql.types._
 import org.apache.avro.Schema
 import org.scalatest._
+import test.util.Fixtures
 
 class AvroToSchemaSpec extends FlatSpec {
   "AvroToSchema" should "create a Spark SQL schema from an Avro schema" in {
-    val avroJsonSchemaStringTest = s"""
-      {
-        "namespace": "com.memsql.spark.examples.avro",
-        "type": "record",
-        "name": "TestSchema",
-        "fields": [
-          {
-            "name": "testBool",
-            "type": "boolean"
-          },
-          {
-            "name": "testDouble",
-            "type": "double"
-          },
-          {
-            "name": "testFloat",
-            "type": "float"
-          },
-          {
-            "name": "testInt",
-            "type": "int"
-          },
-          {
-            "name": "testLong",
-            "type": "long"
-          },
-          {
-            "name": "testNull",
-            "type": "null"
-          },
-          {
-            "name": "testString",
-            "type": "string"
-          }
-        ]
-      }
-    """
-
     val parser = new Schema.Parser()
-    val avroSchema = parser.parse(avroJsonSchemaStringTest)
+    val avroSchema = parser.parse(Fixtures.avroSchema)
     val sparkSchema = AvroToSchema.getSchema(avroSchema)
     val fields = sparkSchema.fields
 
@@ -67,9 +30,12 @@ class AvroToSchemaSpec extends FlatSpec {
     assert(fields(4).dataType == LongType)
 
     assert(fields(5).name == "testNull")
-    assert(fields(5).dataType == StringType)
+    assert(fields(5).dataType == NullType)
 
     assert(fields(6).name == "testString")
     assert(fields(6).dataType == StringType)
+
+    assert(fields(7).name == "testUnion")
+    assert(fields(7).dataType == StringType)
   }
 }

--- a/avro/src/test/scala/test/AvroTransformerSpec.scala
+++ b/avro/src/test/scala/test/AvroTransformerSpec.scala
@@ -1,0 +1,49 @@
+package test
+
+import com.memsql.spark.connector.MemSQLContext
+import com.memsql.spark.etl.api.{UserTransformConfig, UserExtractConfig}
+import com.memsql.spark.examples.avro.{AvroTransformer, AvroRandomExtractor}
+import org.apache.spark.streaming.{StreamingContext, Seconds}
+import test.util.{Fixtures, UnitSpec, LocalSparkContext}
+import spray.json._
+
+class AvroTransformerSpec extends UnitSpec with LocalSparkContext {
+  var ssc: StreamingContext = _
+  var msc: MemSQLContext = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    ssc = new StreamingContext(sc, Seconds(1))
+    msc = new MemSQLContext(sc)
+  }
+
+  val avroConfig = Fixtures.avroConfig.parseJson
+  val extractConfig = UserExtractConfig(class_name = "Test", value = avroConfig)
+  val transformConfig = UserTransformConfig(class_name = "Test", value = avroConfig)
+
+  "AvroRandomTransformer" should "emit a dataframe of properly deserialized data" in {
+    val extractor = new AvroRandomExtractor
+    val transformer = new AvroTransformer
+
+    extractor.initialize(null, null, extractConfig, 0, null)
+    transformer.initialize(null, transformConfig, null)
+
+    val maybeDf = extractor.next(null, 0, msc, null, 0, null)
+    assert(maybeDf.isDefined)
+    val extractedDf = maybeDf.get
+
+    val transformedDf = transformer.transform(msc, extractedDf, null, null)
+
+    val rows = transformedDf.collect()
+    for (row <- rows) {
+      assert(row(0).isInstanceOf[Boolean])
+      assert(row(1).isInstanceOf[Double])
+      assert(row(2).isInstanceOf[Float])
+      assert(row(3).isInstanceOf[Int])
+      assert(row(4).isInstanceOf[Long])
+      assert(row(5) === null)
+      assert(row(6).isInstanceOf[String])
+      assert(row(7).isInstanceOf[String])
+    }
+  }
+}

--- a/avro/src/test/scala/test/util/Fixtures.scala
+++ b/avro/src/test/scala/test/util/Fixtures.scala
@@ -1,0 +1,58 @@
+package test.util
+
+object Fixtures {
+
+  val avroSchema = s"""
+      {
+        "namespace": "com.memsql.spark.examples.avro",
+        "type": "record",
+        "name": "TestSchema",
+        "fields": [
+          {
+            "name": "testBool",
+            "type": "boolean"
+          },
+          {
+            "name": "testDouble",
+            "type": "double"
+          },
+          {
+            "name": "testFloat",
+            "type": "float"
+          },
+          {
+            "name": "testInt",
+            "type": "int"
+          },
+          {
+            "name": "testLong",
+            "type": "long"
+          },
+          {
+            "name": "testNull",
+            "type": "null"
+          },
+          {
+            "name": "testString",
+            "type": "string"
+          },
+          {
+            "name": "testUnion",
+            "type": [
+              "int",
+              "string",
+              "null"
+            ]
+          }
+        ]
+      }
+    """
+
+
+val avroConfig = s"""
+      {
+        "count": 5,
+        "avroSchema": $avroSchema
+      }
+     """
+}


### PR DESCRIPTION
Summary:
* Added explicit typecasts to AvroToRow, so Catalyst won't fail to convert avro.util.utf8 to StringType
* Added explicit handling of Avro Union type to AvroRandomGenerator, and test coverage
* Moved non-serializable objects to per-partition level in AvroTransformer
* Added AvroTransformerSpec, an end-to-end Avro-Streamliner test
* TODO: handle nested Avro Records (to string column? to JSON column?)